### PR TITLE
Made with of draggable fields relative

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
     margin           : 0px;
     margin-left      : 5px;
     padding          : 4px 4px 0 4px;
-    width            : 360px;
+    width            : 80%;
 }
 .que.ordering ul.sortablelist li {
     background-color : #eeeeee;


### PR DESCRIPTION
I found out that together with the plugin active quiz, the fixed with
to 360 px leads to problems when viewed responsive in smaller mobile
devices like smartphones. So I changed the with to a relative value of
80%.

View with fixed width on my smartphone:
![smartphone_anordnen](https://cloud.githubusercontent.com/assets/4711883/8643652/0c4ead38-2937-11e5-90cc-578cc424fae0.png)

View with relative width:
![smarphone_realative](https://cloud.githubusercontent.com/assets/4711883/8643670/3e71a2fc-2937-11e5-98d4-64cb52bad8ff.png)
