### PR TITLE
SVG version of the icon

### DIFF
--- a/pix/icon.svg
+++ b/pix/icon.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#231F20;}
+	.st1{fill:none;stroke:#231F20;stroke-width:3;stroke-miterlimit:10;}
+</style>
+<circle class="st0" cx="4.5" cy="4.5" r="4.5"/>
+<circle class="st0" cx="4.5" cy="27.5" r="4.5"/>
+<circle class="st0" cx="27.5" cy="16" r="4.5"/>
+<line class="st1" x1="11.5" y1="23.9" x2="20.5" y2="19.7"/>
+<line class="st1" x1="11.7" y1="7.7" x2="20.3" y2="12.6"/>
+</svg>


### PR DESCRIPTION
Here is a trivial first contribution from us: and SVG version of the icon.

I left the old .gif in place, because Moodle servers the SVG to browsers that can handle it, and falls back to the GIF for older browsers.