### PR TITLE
Ordering codechecker

### DIFF
--- a/edit_ordering_form.php
+++ b/edit_ordering_form.php
@@ -141,7 +141,7 @@ class qtype_ordering_edit_form extends question_edit_form {
 
         // Adding feedback fields (=Combined feedback).
         $this->add_combined_feedback_fields(false);
-        
+
         // Adding interactive settings (=Multiple tries).
         $this->add_interactive_settings(false, false);
     }
@@ -224,19 +224,19 @@ class qtype_ordering_edit_form extends question_edit_form {
 
         $defaultanswerformat = get_config('qtype_ordering', 'defaultanswerformat');
 
-        $repeats = 'count'.$name.'s'; // e.g. countanswers
+        $repeats = 'count'.$name.'s'; // E.g. countanswers.
         if ($mform->elementExists($repeats)) {
-            // Use mform element to get number of repeats
+            // Use mform element to get number of repeats.
             $repeats = $mform->getElement($repeats)->getValue();
         } else {
-            // Determine number of repeats by object sniffing
+            // Determine number of repeats by object sniffing.
             $repeats = 0;
             while ($mform->elementExists($name."[$repeats]")) {
                 $repeats++;
             }
         }
 
-        for ($i=0; $i < $repeats; $i++) {
+        for ($i = 0; $i < $repeats; $i++) {
             $editor = $mform->getElement($name."[$i]");
 
             if (isset($ids[$i])) {
@@ -292,9 +292,9 @@ class qtype_ordering_edit_form extends question_edit_form {
 
         // Preprocess feedback.
         $question = $this->data_preprocessing_combined_feedback($question);
-        
+
         $question = $this->data_preprocessing_hints($question, false, false);
-        
+
         // Preprocess answers and fractions.
         $question->answer     = array();
         $question->fraction   = array();
@@ -421,13 +421,13 @@ class qtype_ordering_edit_form extends question_edit_form {
      */
     protected function get_addcount_options($type, $max=10) {
 
-        // cache plugin name
+        // Cache plugin name.
         $plugin = $this->plugin_name();
 
-        // generate options
+        // Generate options.
         $options = array();
-        for ($i=1; $i<=$max; $i++) {
-            if ($i==1) {
+        for ($i = 1; $i <= $max; $i++) {
+            if ($i == 1) {
                 $options[$i] = get_string('addsingle'.$type, $plugin);
             } else {
                 $options[$i] = get_string('addmultiple'.$type.'s', $plugin, $i);
@@ -444,10 +444,10 @@ class qtype_ordering_edit_form extends question_edit_form {
      */
     protected function add_repeat_elements($mform, $type, $elements, $options) {
 
-        // cache plugin name
+        // Cache plugin name.
         $plugin = $this->plugin_name();
 
-        // cache element names
+        // Cache element names.
         $types = $type.'s';
         $addtypes = 'add'.$types;
         $counttypes = 'count'.$types;
@@ -458,22 +458,22 @@ class qtype_ordering_edit_form extends question_edit_form {
 
         $count = optional_param($addtypescount, self::NUM_ITEMS_ADD, PARAM_INT);
 
-        $label = ($count==1 ? 'addsingle'.$type : 'addmultiple'.$types);
+        $label = ($count == 1 ? 'addsingle'.$type : 'addmultiple'.$types);
         $label = get_string($label, $plugin, $count);
 
         $this->repeat_elements($elements, $repeats, $options, $counttypes, $addtypes, $count, $label, true);
 
-        // remove the original "Add xxx" button ...
+        // Remove the original "Add xxx" button ...
         $mform->removeElement($addtypes);
 
-        // ... and replace it with "Add" button + select group
+        // ... and replace it with "Add" button + select group.
         $options = $this->get_addcount_options($type);
         $mform->addGroup(array(
             $mform->createElement('submit', $addtypes, get_string('add')),
             $mform->createElement('select', $addtypescount, '', $options)
         ), $addtypesgroup, '', ' ', false);
 
-        // set default value and type of select element
+        // Set default value and type of select element.
         $mform->setDefault($addtypescount, $count);
         $mform->setType($addtypescount, PARAM_INT);
     }

--- a/question.php
+++ b/question.php
@@ -224,7 +224,7 @@ class qtype_ordering_question extends question_graded_automatically {
         if (array_key_exists($name, $response)) {
             $items = explode(',', $response[$name]);
         } else {
-            $items = array(); // shouldn't happen !!
+            $items = array(); // Shouldn't happen !!
         }
         $answerids = array();
         foreach ($this->answers as $answer) {
@@ -234,10 +234,10 @@ class qtype_ordering_question extends question_graded_automatically {
             if (array_key_exists($item, $answerids)) {
                 $item = $this->answers[$answerids[$item]];
                 $item = $this->html_to_text($item->answer, $item->answerformat);
-                $item = shorten_text($item, 10, true); // force truncate at 10 chars
+                $item = shorten_text($item, 10, true); // Force truncate at 10 chars.
                 $items[$i] = $item;
             } else {
-                $items[$i] = ''; // shouldn't happen !!
+                $items[$i] = ''; // Shouldn't happen !!
             }
         }
         return implode('; ', array_filter($items));
@@ -702,38 +702,38 @@ class qtype_ordering_question extends question_graded_automatically {
         // Var $subsets is the collection of all subsets within $positions.
         $subsets = array();
 
-        // loop through the values at each position
+        // Loop through the values at each position.
         foreach ($positions as $p => $value) {
 
-            // is $value a "new" value that cannot be added to any $subsets found so far
+            // Is $value a "new" value that cannot be added to any $subsets found so far?
             $isnew = true;
 
-            // an array of new and saved subsets to be added to $subsets
+            // An array of new and saved subsets to be added to $subsets.
             $new = array();
 
-            // append the current value to any subsets to which it belongs
-            // i.e. any subset whose end value is less than the current value
+            // Append the current value to any subsets to which it belongs
+            // i.e. any subset whose end value is less than the current value.
             foreach ($subsets as $s => $subset) {
 
-                // get value at end of $subset
+                // Get value at end of $subset.
                 $end = $positions[end($subset)];
 
                 switch (true) {
 
                     case ($value == ($end + 1)):
-                        // for a contiguous value, we simply append $p to the subset
+                        // For a contiguous value, we simply append $p to the subset.
                         $isnew = false;
                         $subsets[$s][] = $p;
                         break;
 
                     case $contiguous:
-                        // if the $contiguous flag is set, we ignore non-contiguous values
+                        // If the $contiguous flag is set, we ignore non-contiguous values.
                         break;
 
                     case ($value > $end):
-                        // for a non-contiguous value, we save the subset so far,
+                        // For a non-contiguous value, we save the subset so far,
                         // because a value between $end and $value may be found later,
-                        // and then append $p to the subset
+                        // and then append $p to the subset.
                         $isnew = false;
                         $new[] = $subset;
                         $subsets[$s][] = $p;
@@ -741,29 +741,16 @@ class qtype_ordering_question extends question_graded_automatically {
                 }
             }
 
-            // if this is a "new" value, add it as a new subset
+            // If this is a "new" value, add it as a new subset.
             if ($isnew) {
                 $new[] = array($p);
             }
 
-            // append any "new" subsets that were found during this iteration
+            // Append any "new" subsets that were found during this iteration.
             if (count($new)) {
                 $subsets = array_merge($subsets, $new);
             }
         }
-
-        // remove short subsets, that are subsets of longer subsets
-        //$keys = array();
-        //foreach ($subsets as $s => $subset) {
-        //    $key = implode(',', $subset);
-        //    $search = implode(',(\d+,)*', $subset);
-        //    $search = preg_grep("/$search/", $keys);
-        //    if (count($search)) {
-        //        //unset($subsets[$s]);
-        //    } else {
-        //        //$keys[] = $key;
-        //    }
-        //}
 
         return $subsets;
     }

--- a/questiontype.php
+++ b/questiontype.php
@@ -90,26 +90,25 @@ class qtype_ordering extends question_type {
 
         // Insert all the new answers.
         foreach ($question->answer as $i => $answer) {
-
-			$answertext = '';
-			$answerformat = 0;
-			$answeritemid = null;
+            $answertext = '';
+            $answerformat = 0;
+            $answeritemid = null;
 
             // Extract $answer fields.
             if (is_string($answer)) {
-            	// import from file
-				$answertext = $answer;
+                // Import from file.
+                $answertext = $answer;
             } else if (is_array($answer)) {
-            	// input from browser
-            	if (isset($answer['text'])) {
-					$answertext = $answer['text'];
-            	}
-            	if (isset($answer['format'])) {
-					$answerformat = $answer['format'];
-            	}
-				if (isset($answer['itemid'])) {
-					$answeritemid = $answer['itemid'];
-				}
+                // Input from browser.
+                if (isset($answer['text'])) {
+                    $answertext = $answer['text'];
+                }
+                if (isset($answer['format'])) {
+                    $answerformat = $answer['format'];
+                }
+                if (isset($answer['itemid'])) {
+                    $answeritemid = $answer['itemid'];
+                }
             }
 
             // Reduce simple <p>...</p> to plain text.
@@ -364,54 +363,51 @@ class qtype_ordering extends question_type {
         $answers = preg_split('/[\r\n]+/', $matches[6]);
         $answers = array_filter($answers);
 
-		if (empty($question)) {
-			$text = implode(PHP_EOL, $lines);
-			$text = trim($text);
-			if ($pos = strpos($text, '{')) {
-				$text = substr($text, 0, $pos);
-			}
+        if (empty($question)) {
+            $text = implode(PHP_EOL, $lines);
+            $text = trim($text);
+            if ($pos = strpos($text, '{')) {
+                $text = substr($text, 0, $pos);
+            }
 
-			// extract name
-			$name = false;
-			if (substr($text, 0, 2) == '::') {
-				$text = substr($text, 2);
-				$pos = strpos($text, '::');
-				if (is_numeric($pos)) {
-					$name = substr($text, 0, $pos);
-					$name = $format->clean_question_name($name);
-					$text = trim(substr($text, $pos + 2));
-				}
-			}
+            // Extract name.
+            $name = false;
+            if (substr($text, 0, 2) == '::') {
+                $text = substr($text, 2);
+                $pos = strpos($text, '::');
+                if (is_numeric($pos)) {
+                    $name = substr($text, 0, $pos);
+                    $name = $format->clean_question_name($name);
+                    $text = trim(substr($text, $pos + 2));
+                }
+            }
 
-			// extract question text format
-			$format = FORMAT_MOODLE;
-			if (substr($text, 0, 1) == '[') {
-				$text = substr($text, 1);
-				$pos = strpos($text, ']');
-				if (is_numeric($pos)) {
-					$format = substr($text, 0, $pos);
-					switch ($format) {
-						case 'html':     $format = FORMAT_HTML;     break;
-						case 'plain':    $format = FORMAT_PLAIN;    break;
-						case 'markdown': $format = FORMAT_MARKDOWN; break;
-						case 'moodle':   $format = FORMAT_MOODLE;   break;
-					}
-					$text = trim(substr($text, $pos + 1)); // Remove name from text.
-				}
-			}
+            // Extract question text format.
+            $format = FORMAT_MOODLE;
+            if (substr($text, 0, 1) == '[') {
+                $text = substr($text, 1);
+                $pos = strpos($text, ']');
+                if (is_numeric($pos)) {
+                    $format = substr($text, 0, $pos);
+                    switch ($format) {
+                        case 'html':     $format = FORMAT_HTML;     break;
+                        case 'plain':    $format = FORMAT_PLAIN;    break;
+                        case 'markdown': $format = FORMAT_MARKDOWN; break;
+                        case 'moodle':   $format = FORMAT_MOODLE;   break;
+                    }
+                    $text = trim(substr($text, $pos + 1)); // Remove name from text.
+                }
+            }
 
-			$question = new stdClass();
-			$question->name = $name;
-			$question->questiontext = $text;
-			$question->questiontextformat = $format;
-			$question->generalfeedback = '';
-			$question->generalfeedbackformat = FORMAT_MOODLE;
-		}
+            $question = new stdClass();
+            $question->name = $name;
+            $question->questiontext = $text;
+            $question->questiontextformat = $format;
+            $question->generalfeedback = '';
+            $question->generalfeedbackformat = FORMAT_MOODLE;
+        }
 
         $question->qtype = 'ordering';
-
-        // Fix empty or long question name.
-        //$question->name = $this->fix_questionname($question->name, $questionname);
 
         // Set "selectcount" field from $selectcount.
         if (is_numeric($selectcount) && $selectcount > 2 && $selectcount <= count($answers)) {
@@ -573,7 +569,8 @@ class qtype_ordering extends question_type {
 
         $output .= $question->questiontext.'{';
 
-        list($layouttype, $selecttype, $selectcount, $gradingtype, $showgrading) = $this->extract_layout_select_count_grading($question);
+        list($layouttype, $selecttype, $selectcount, $gradingtype, $showgrading) =
+                $this->extract_layout_select_count_grading($question);
         $output .= ">$selectcount $selecttype $layouttype $gradingtype $showgrading".PHP_EOL;
 
         foreach ($question->options->answers as $answer) {
@@ -596,7 +593,8 @@ class qtype_ordering extends question_type {
         global $CFG;
         require_once($CFG->dirroot.'/question/type/ordering/question.php');
 
-        list($layouttype, $selecttype, $selectcount, $gradingtype, $showgrading) = $this->extract_layout_select_count_grading($question);
+        list($layouttype, $selecttype, $selectcount, $gradingtype, $showgrading) =
+                $this->extract_layout_select_count_grading($question);
 
         $output = '';
         $output .= "    <layouttype>$layouttype</layouttype>\n";

--- a/questiontype.php
+++ b/questiontype.php
@@ -830,12 +830,3 @@ class qtype_ordering extends question_type {
         $question->showgrading = $showgrading;
     }
 }
-
-if (function_exists('question_register_questiontype')) { // Moodle 2.0
-    class qtype_ordering_options_qtype extends qtype_ordering {
-        function name() {
-            return 'ordering';
-        }
-    }
-    question_register_questiontype(new qtype_ordering_options_qtype());
-}

--- a/renderer.php
+++ b/renderer.php
@@ -78,10 +78,8 @@ class qtype_ordering_renderer extends qtype_with_combined_feedback_renderer {
 
         $result = '';
 
-        if ($options->readonly) {
-            // Items cannot be dragged in readonly mode.
-        } else {
-            // Initialise JavaScript.
+        // Initialise JavaScript if not in readonly mode (Items cannot be dragged in readonly mode).
+        if (!$options->readonly) {
             $params = array($sortableid, $responseid);
             $PAGE->requires->js_call_amd('qtype_ordering/reorder', 'init', $params);
         }
@@ -91,8 +89,8 @@ class qtype_ordering_renderer extends qtype_with_combined_feedback_renderer {
         $printeditems = false;
         if (count($currentresponse)) {
 
-            // initialize the cache for the  answers' md5keys
-            // this represents the initial position of the items
+            // Initialize the cache for the  answers' md5keys
+            // this represents the initial position of the items.
             $md5keys = array();
 
             // Set layout class.
@@ -122,13 +120,13 @@ class qtype_ordering_renderer extends qtype_with_combined_feedback_renderer {
                 // Set the CSS class and correctness img for this response.
                 switch ($options->correctness) {
 
-                    case question_display_options::HIDDEN: // =0
-                    case question_display_options::EDITABLE: // =2
+                    case question_display_options::HIDDEN: // HIDDEN=0.
+                    case question_display_options::EDITABLE: // EDITABLE=2.
                         $class = 'sortableitem';
                         $img = '';
                         break;
 
-                    case question_display_options::VISIBLE: // =1
+                    case question_display_options::VISIBLE: // VISIBLE=1.
                         $score = $this->get_ordering_item_score($question, $position, $answerid);
                         list($score, $maxscore, $fraction, $percent, $class, $img) = $score;
                         break;
@@ -151,8 +149,8 @@ class qtype_ordering_renderer extends qtype_with_combined_feedback_renderer {
                 $params = array('class' => $class, 'id' => $answer->md5key);
                 $result .= html_writer::tag('li', $img.$answertext, $params);
 
-                // cache this answer key
-                $md5keys[] =  $question->answers[$answerid]->md5key;
+                // Cache this answer key.
+                $md5keys[] = $question->answers[$answerid]->md5key;
             }
         }
 
@@ -201,7 +199,7 @@ class qtype_ordering_renderer extends qtype_with_combined_feedback_renderer {
             $plugin = 'qtype_ordering';
             $question = $qa->get_question();
 
-            // show grading details if they are required
+            // Show grading details if they are required.
             if ($question->options->showgrading) {
 
                 // Fetch grading type.

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -65,7 +65,7 @@ class qtype_ordering_test extends advanced_testcase {
         $questiondata = test_question_maker::get_question_data('ordering');
         $formdata = test_question_maker::get_question_form_data('ordering');
 
-        /** @var core_question_generator $generator */
+        /* @var core_question_generator $generator */
         $generator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $cat = $generator->create_question_category([]);
 

--- a/version.php
+++ b/version.php
@@ -28,6 +28,6 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->cron      = 0;
 $plugin->component = 'qtype_ordering';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->requires  = 2015051100; // Moodle 2.9
+$plugin->requires  = 2015051100; // Moodle 2.9.
 $plugin->version   = 2019020885;
 $plugin->release   = '2019-02-08 (85)';


### PR DESCRIPTION
Hi Gordon,
I have done some other minor changes (no changes to the code behaviour, just some code checker issues).
I kept them simple and easy for each file as you see it for each commit. Please feel free to squash them in one commit if required.

I have deleted some commented code which I guess can be retrieved from git history if they were commented out temporarily.

After these commits the code checker results looks like: 

---------------------------------------------------------------
Files found: 25
question/type/ordering/amd/src/autoscroll.js
question/type/ordering/amd/src/drag_reorder.js
question/type/ordering/amd/src/dragdrop.js
question/type/ordering/amd/src/key_codes.js
question/type/ordering/amd/src/reorder.js
question/type/ordering/backup/moodle1/lib.php
question/type/ordering/backup/moodle2/backup_qtype_ordering_plugin.class.php
question/type/ordering/backup/moodle2/restore_qtype_ordering_plugin.class.php
question/type/ordering/classes/privacy/provider.php
question/type/ordering/db/upgrade.php
question/type/ordering/edit_ordering_form.php
question/type/ordering/lang/en/qtype_ordering.php
question/type/ordering/lib.php
question/type/ordering/question.php - 4 error(s) and 3 warning(s)
question/type/ordering/questiontype.php - 8 error(s) and 0 warning(s)
question/type/ordering/readme.txt
question/type/ordering/renderer.php
question/type/ordering/settings.php
question/type/ordering/styles.css
question/type/ordering/tests/behat/behat_qtype_ordering.php
question/type/ordering/tests/helper.php
question/type/ordering/tests/question_test.php
question/type/ordering/tests/questiontype_test.php
question/type/ordering/tests/walkthrough_test.php
question/type/ordering/version.php
Total: 12 error(s) and 3 warning(s)
question/type/ordering/question.php
····///////////////////////////////////////////////////////
454: 55 slashes comments are not allowed; use "// Comment" instead
····///////////////////////////////////////////////////////
457: 55 slashes comments are not allowed; use "// Comment" instead
····///////////////////////////////////////////////////////
487: 55 slashes comments are not allowed; use "// Comment" instead
····///////////////////////////////////////////////////////
489: 55 slashes comments are not allowed; use "// Comment" instead
····///////////////////////////////////////////////////////
454: Inline comments must start with a capital letter, digit or 3-dots sequence
····///////////////////////////////////////////////////////
457: Inline comments must end in full-stops, exclamation marks, or question marks
····///////////////////////////////////////////////////////
489: Inline comments must end in full-stops, exclamation marks, or question marks
question/type/ordering/questiontype.php
························case·'html':·····$format·=·FORMAT_HTML;·····break;
393: Closing brace must be on a line by itself
························case·'plain':····$format·=·FORMAT_PLAIN;····break;
394: Closing brace must be on a line by itself
························case·'markdown':·$format·=·FORMAT_MARKDOWN;·break;
395: Closing brace must be on a line by itself
························case·'moodle':···$format·=·FORMAT_MOODLE;···break;
396: Closing brace must be on a line by itself
············case·FORMAT_HTML:·····$output·.=·'[html]';·····break;
564: Closing brace must be on a line by itself
············case·FORMAT_PLAIN:····$output·.=·'[plain]';····break;
565: Closing brace must be on a line by itself
············case·FORMAT_MARKDOWN:·$output·.=·'[markdown]';·break;
566: Closing brace must be on a line by itself
············case·FORMAT_MOODLE:···$output·.=·'[moodle]';···break;
567: Closing brace must be on a line by itself
-----------------------------------------------------------------------------------------  

The switch statements were easily readable when each case is in one line, and having header for some section in a code using /////// was reasonable and I left them, as you see.

Many thanks,
Mahmoud



