### PR TITLE
Qtype ordering should not allow duplicatue items

### DIFF
--- a/edit_ordering_form.php
+++ b/edit_ordering_form.php
@@ -363,12 +363,23 @@ class qtype_ordering_edit_form extends question_edit_form {
         $plugin = 'qtype_ordering';
 
         $answercount = 0;
+        $list = [];
         foreach ($data['answer'] as $answer) {
             if (is_array($answer)) {
-                $answer = $answer['text'];
+                $answer = trim($answer['text']);
             }
             if (trim($answer) == '') {
                 continue; // Skip empty answer.
+            }
+            // Check on duplicates.
+            if ($answer && in_array($answer, $list)) {
+                $draggableitem = new stdClass();
+                $draggableitem->number = array_search($answer, $list) + 1;
+                $draggableitem->text = $answer;
+
+                $errors["answer[$answercount]"] =  get_string('err_draggableitemsduplication', 'qtype_ordering', $draggableitem);
+            } else {
+                $list[] = trim($answer);
             }
             $answercount++;
         }

--- a/lang/en/qtype_ordering.php
+++ b/lang/en/qtype_ordering.php
@@ -35,6 +35,7 @@ $string['defaultanswerformat'] = 'Default answer format';
 $string['defaultquestionname'] = 'Drag the following items into the correct order.';
 
 $string['editingordering'] = 'Editing ordering question';
+$string['err_draggableitemsduplication'] = 'Dupplication of draggable items are not allowed. The string "{$a->text}" is already used in Draggable item {$a->number}.';
 
 $string['gradedetails'] = 'Grade details';
 $string['gradingtype'] = 'Grading type';

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -35,3 +35,15 @@ Feature: Test editing an Ordering question
       | Question name | Edited Ordering |
     And I press "id_submitbutton"
     Then I should see "Edited Ordering"
+
+  @javascript @_switch_window
+  Scenario: Editing an ordering question and making sure the form does not allow duplication of draggables
+    When I click on "Edit" "link" in the "Ordering for editing" "table_row"
+    And I set the following fields to these values:
+      | Draggable item 4 | Object |
+    And I press "id_submitbutton"
+    Then  I should see "Dupplication of draggable items are not allowed. The string \"Object\" is already used in Draggable item 2."
+    Given I set the following fields to these values:
+      | Draggable item 4 | Dynamic |
+    And I press "id_submitbutton"
+    Then I should see "Ordering for editing"


### PR DESCRIPTION
Hi Gordon,
Hope you are keeping well.
Just another minor change:
We do not want that the question author accidentally create duplicate draggable items because it is not fair to students for assessment purposes. So the draggable items should be validated on save when the question is created/edited.


