### PR TITLE
Fix db error when customizing language

### DIFF
--- a/lang/en/qtype_ordering.php
+++ b/lang/en/qtype_ordering.php
@@ -82,10 +82,10 @@ $string['notenoughanswers'] = 'Ordering questions must have more than {$a} answe
 $string['numberingstyle'] = 'Number the choices?';
 $string['numberingstylenone'] = 'No numbering';
 $string['numberingstyle123'] = '1., 2., 3., ...';
-$string['numberingstyleabc'] = 'a., b., c., ...';
-$string['numberingstyleABC'] = 'A., B., C., ...';
-$string['numberingstyleiii'] = 'i., ii., iii., ...';
-$string['numberingstyleIII'] = 'I., II., III., ...';
+$string['numberingstyleabcl'] = 'a., b., c., ...';
+$string['numberingstyleABCU'] = 'A., B., C., ...';
+$string['numberingstyleiiil'] = 'i., ii., iii., ...';
+$string['numberingstyleIIIU'] = 'I., II., III., ...';
 $string['numberingstyle_desc'] = 'The default numbering style.';
 $string['numberingstyle_help'] = 'Choose the numbering style for draggable items in this question.';
 

--- a/question.php
+++ b/question.php
@@ -838,11 +838,11 @@ class qtype_ordering_question extends question_graded_automatically {
     public static function get_numbering_styles($style=null) {
         $plugin = 'qtype_ordering';
         $styles = array('none' => get_string('numberingstylenone', $plugin),
-                        'abc'  => get_string('numberingstyleabc',  $plugin),
-                        'ABC'  => get_string('numberingstyleABC',  $plugin),
+                        'abc'  => get_string('numberingstyleabcl', $plugin),
+                        'ABC'  => get_string('numberingstyleABCU', $plugin),
                         '123'  => get_string('numberingstyle123',  $plugin),
-                        'iii'  => get_string('numberingstyleiii',  $plugin),
-                        'III'  => get_string('numberingstyleIII',  $plugin));
+                        'iii'  => get_string('numberingstyleiiil', $plugin),
+                        'III'  => get_string('numberingstyleIIIU', $plugin));
         return self::get_types($styles, $style);
     }
 }


### PR DESCRIPTION
When customizing language in Moodle, moodle loads language pack into DB.
Because the table/index are case insensitive and Moodle uses lang,
componentid and stringid as unique constrain (mdl_toolcust_lancomstr_uix)
for tool_customlang table. It will trigger the following error when
loading "numberingstyleABC" and "numberingstyleabc" keys:

Duplicate entry 'en-90-numberingstyleABC' for key
'mdl_toolcust_lancomstr_uix'