### PR TITLE
Numberingstyle does not display properly in notactive mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,8 +8,7 @@
 .que.ordering .sortablelist {
     float            : left;
     list-style-type  : none;
-    margin           : 0 0 0 5px;
-    padding          : 4px;
+    margin           : 0 0 0 8px;
 }
 .que.ordering .sortablelist.active {
     border           : 1px dotted #333;
@@ -45,13 +44,13 @@
 .que.ordering .sortablelist.numberingabc li {
     list-style-type  : lower-alpha;
 }
-.que.ordering .sortablelist.numberingABC li {
+.que.ordering .sortablelist.numberingABCD li {
     list-style-type  : upper-alpha;
 }
-.que.ordering .sortablelist.numberingiii li  {
+.que.ordering .sortablelist.numberingiii li {
     list-style-type  : lower-roman;
 }
-.que.ordering .sortablelist.numberingIII li {
+.que.ordering .sortablelist.numberingIIII li {
     list-style-type  : upper-roman;
 }
 


### PR DESCRIPTION
Hi Gordon,
There was some minor issues with the way numbering were displayed:
Basically there were tow issues:

1. The numbering style for decimal, lower-alpha and lower-roman where displaying, however, when answering a question and the question is not active, the numbering does not show fully.
2. the numbering style upper-alpha and upper-roman did not show at all even in active mode (that was a minor issue with renaming ABCD to ABC, etc.

Anyway, this is a minor tweaks in css file only.

Many thanks,
Mahmoud
![numbering_css_issues1](https://user-images.githubusercontent.com/391771/67413222-a6a30580-f5b8-11e9-9e9f-57cfcc60858e.PNG)
![numbering_css_issues2](https://user-images.githubusercontent.com/391771/67413232-ae62aa00-f5b8-11e9-9d8a-d980fad93192.PNG)


