### PR TITLE
Update Behat tests to use the MDL-66821 changes

### DIFF
--- a/tests/behat/backup_and_restore.feature
+++ b/tests/behat/backup_and_restore.feature
@@ -29,7 +29,7 @@ Feature: Test duplicating a quiz containing a Ordering question
     And I restore "test_backup.mbz" backup into a new course using this options:
       | Schema | Course name | Course 2 |
     And I navigate to "Question bank" in current page administration
-    And I click on "Edit" "link" in the "Moodle" "table_row"
+    And I choose "Edit question" action for "Moodle" in the question bank
     Then the following fields match these values:
       | Question name                      | Moodle |
       | Question text                      | Put these words in order. |

--- a/tests/behat/behat_qtype_ordering.php
+++ b/tests/behat/behat_qtype_ordering.php
@@ -41,7 +41,7 @@ class behat_qtype_ordering extends behat_base {
      * @return string the xpath expression.
      */
     protected function item_xpath_by_lable($label) {
-        return '//li[contains(@class, "sortableitem ") and contains(normalize-space(.), "' . $this->escape($label) . '")]';
+        return '//li[@class = "sortableitem" and contains(normalize-space(.), "' . $this->escape($label) . '")]';
     }
 
     /**
@@ -50,7 +50,7 @@ class behat_qtype_ordering extends behat_base {
      * @return string the xpath expression.
      */
     protected function item_xpath_by_position($position) {
-        return '//li[contains(@class, "sortableitem ")][' . $position . ']';
+        return '//li[@class = "sortableitem"][' . $position . ']';
     }
 
     /**

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -26,7 +26,7 @@ Feature: Test editing an Ordering question
 
   @javascript @_switch_window
   Scenario: Edit an Ordering question
-    When I click on "Edit" "link" in the "Ordering for editing" "table_row"
+    When I choose "Edit question" action for "Ordering for editing" in the question bank
     And I set the following fields to these values:
       | Question name ||
     And I press "id_submitbutton"
@@ -38,7 +38,7 @@ Feature: Test editing an Ordering question
 
   @javascript @_switch_window
   Scenario: Editing an ordering question and making sure the form does not allow duplication of draggables
-    When I click on "Edit" "link" in the "Ordering for editing" "table_row"
+    When I choose "Edit question" action for "Ordering for editing" in the question bank
     And I set the following fields to these values:
       | Draggable item 4 | Object |
     And I press "id_submitbutton"

--- a/tests/behat/preview.feature
+++ b/tests/behat/preview.feature
@@ -30,7 +30,7 @@ Feature: Preview an Ordering question
     And I switch to "questionpreview" window
     And I set the field "How questions behave" to "Immediate feedback"
     And I press "Start again with these options"
-    # The test was unreliable unless if an item rendomly stared in the right place.
+    # The test was unreliable unless if an item randomly started in the right place.
     # So we first moved each item to the last place, before putting it into the right place.
     And I drag "Modular" to space "6" in the ordering question
     And I drag "Modular" to space "1" in the ordering question

--- a/tests/behat/preview.feature
+++ b/tests/behat/preview.feature
@@ -26,7 +26,7 @@ Feature: Preview an Ordering question
 
   @javascript @_switch_window
   Scenario: Preview an Ordering question and submit a correct response.
-    When I click on "Preview" "link" in the "ordering-001" "table_row"
+    When I choose "Preview" action for "ordering-001" in the question bank
     And I switch to "questionpreview" window
     And I set the field "How questions behave" to "Immediate feedback"
     And I press "Start again with these options"


### PR DESCRIPTION
Hi Gordon.

At the point where you start using Moodle 3.8, you will need these changes, or all your Behat tests will start to fail.

And, as soon as you are using 3.7.3 or 3.6.7 for development it will be safe to incorporate these changes.

The explantion is here: https://github.com/moodle/moodle/blob/e04a73ccc06e18d8d3b3661f8f9bc16911747830/question/type/upgrade.txt#L5. I am afraid it is all my fault, but was necessary.


Also, while testing these changes, I found another test that was failing, and fixed it.