### PR TITLE
Fixed error in Moodle 3.11 on declaration of qtype_ordering_edit_form::get_default_value()

### DIFF
--- a/edit_ordering_form.php
+++ b/edit_ordering_form.php
@@ -418,8 +418,8 @@ class qtype_ordering_edit_form extends question_edit_form {
      * @param string|mixed|null $default Default value (optional, default = null)
      * @return string|mixed|null Default value for field with this $name
      */
-    protected function get_default_value($name, $default=null) {
-        return get_user_preferences("qtype_ordering_$name", $default);
+    protected function get_default_value(string $name, $default): ?string {
+        return get_user_preferences($this->plugin_name() . '_' . $name, $default ?? '0');
     }
 
     /**


### PR DESCRIPTION
In Moodle 3.11, when trying to create a new question of type _ordering_ this error is thrown:

> Fatal error: Declaration of qtype_ordering_edit_form::get_default_value($name, $default = NULL) must be compatible with question_edit_form::get_default_value(string $name, $default): ?string in /path/to/moodle/question/type/ordering/edit_ordering_form.php on line 0

The error is caused by a change in the definition of the function _qtype_ordering_edit_form::get_default_value()_ in Moodle core. This _Pull Request_ fixes it.