### PR TITLE
Ordering: Improper alignment of feedback with Horizontal layout of items

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -308,7 +308,7 @@ class qtype_ordering_renderer extends qtype_with_combined_feedback_renderer {
         if ($showcorrect) {
             $sortableitem = $question->get_ordering_layoutclass();
             $output .= html_writer::tag('p', get_string('correctorder', 'qtype_ordering'));
-            $output .= html_writer::start_tag('ol', array('class' => 'correctorder'));
+            $output .= html_writer::start_tag('ol', array('class' => 'correctorder ' . $sortableitem));
             $correctresponse = $question->correctresponse;
             foreach ($correctresponse as $position => $answerid) {
                 $answer = $question->answers[$answerid];

--- a/styles.css
+++ b/styles.css
@@ -62,8 +62,9 @@
     list-style-type  : upper-roman;
 }
 
-.que.ordering .sortablelist.horizontal li {
-    float            : left;
+.que.ordering .sortablelist.horizontal {
+    display: flex;
+    flex-wrap: wrap;
 }
 .que.ordering .sortablelist.vertical li {
     min-height       : 18px;
@@ -125,15 +126,20 @@
 .que.ordering div.rightanswer {
     overflow: auto;
 }
+.que.ordering div.rightanswer ol.correctorder {
+    padding-inline-start: 16px;
+}
+.que.ordering div.rightanswer ol.correctorder.horizontal {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+}
 .que.ordering div.rightanswer ol.correctorder li.horizontal {
-    float            : left;
     margin-left      : 24px;
     margin-right     : 24px;
 }
-.que.ordering div.rightanswer ol.correctorder li.horizontal:first-child {
-    margin-left      : 0;
-}
 .que.ordering div.rightanswer ol.correctorder li.vertical {
+    margin-left: 24px;
 }
 
 /* the width restriction can be limited to editors for draggable items


### PR DESCRIPTION
Hi, @gbateson 

I have created this commit to fix some minor bugs in the ordering question with the setting 'Layout of items' is set to horizontal. I have attached the image error and result below.

Could you please help me to review it?

Many thanks

![error1](https://user-images.githubusercontent.com/32395146/130576106-b5410a38-6eb1-4476-810f-58ba93f8091d.png)
![error2](https://user-images.githubusercontent.com/32395146/130576117-7653c315-1567-4df9-b576-5747df40e680.png)
<img width="1193" alt="result1" src="https://user-images.githubusercontent.com/32395146/130576451-32c06703-1cf5-487a-bef9-f5c743a995a2.png">
<img width="1241" alt="result2" src="https://user-images.githubusercontent.com/32395146/130576462-dcc4fc5a-5d27-4be4-9f44-db57d9de7ce5.png">