### PR TITLE
PHPunit: Some compatibilirty in question_test & questiontype_test

### DIFF
--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -281,7 +281,11 @@ class qtype_ordering_question_test extends advanced_testcase {
         // Create an Ordering question.
         $question = test_question_maker::make_question('ordering');
         $question->start_attempt(new question_attempt_pending_step(), 1);
-        $this->assertArraySubset($this->get_response($question, self::CORRECTORDER), $question->get_correct_response());
+
+        // The assertEquals() is used to replace the deprecated assertArraySubset(), because in this one case
+        // they are equals. For more info see https://thephp.cc/articles/migrating-to-phpunit-9
+        // and https://github.com/rdohms/phpunit-arraysubset-asserts.
+        $this->assertEquals($this->get_response($question, self::CORRECTORDER), $question->get_correct_response());
     }
     public function test_is_same_response() {
         // Create an Ordering question.
@@ -396,7 +400,7 @@ class qtype_ordering_question_test extends advanced_testcase {
                 'Environment' => new question_classified_response(6, 'Position 6', 0.1666667),
         ];
 
-        $this->assertEquals($expected, $classifiedresponse, '', 0.0000005);
+        $this->assertEqualsWithDelta($expected, $classifiedresponse, 0.0000005, '');
     }
 
     public function test_classify_response_partially_correct() {
@@ -415,6 +419,6 @@ class qtype_ordering_question_test extends advanced_testcase {
                 'Environment' => new question_classified_response(6, 'Position 6', 0.1666667),
         ];
 
-        $this->assertEquals($expected, $classifiedresponse, '', 0.0000005);
+        $this->assertEqualsWithDelta($expected, $classifiedresponse, 0.0000005, '');
     }
 }

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -41,11 +41,11 @@ class qtype_ordering_test extends advanced_testcase {
     /** @var qtype_ordering instance of the question type class to test. */
     protected $qtype;
 
-    protected function setUp() {
+    protected function setUp(): void {
         $this->qtype = new qtype_ordering();
     }
 
-    protected function tearDown() {
+    protected function tearDown(): void {
         $this->qtype = null;
     }
 
@@ -82,13 +82,15 @@ class qtype_ordering_test extends advanced_testcase {
 
         foreach ($questiondata as $property => $value) {
             if (!in_array($property, array('id', 'version', 'timemodified', 'timecreated', 'options', 'stamp'))) {
-                $this->assertAttributeEquals($value, $property, $actualquestiondata);
+                $this->assertContainsEquals($value, (array)$actualquestiondata);
+                $this->assertContainsEquals($property, array_keys((array)$actualquestiondata));
             }
         }
 
         foreach ($questiondata->options as $optionname => $value) {
             if ($optionname != 'answers') {
-                $this->assertAttributeEquals($value, $optionname, $actualquestiondata->options);
+                $this->assertContainsEquals($value, (array)$actualquestiondata->options);
+                $this->assertContainsEquals($optionname, array_keys((array)$actualquestiondata->options));
             }
         }
 
@@ -96,9 +98,11 @@ class qtype_ordering_test extends advanced_testcase {
             $actualanswer = array_shift($actualquestiondata->options->answers);
             foreach ($answer as $ansproperty => $ansvalue) {
                 if ($ansproperty === 'question') {
-                    $this->assertAttributeEquals($returnedfromsave->id, $ansproperty, $actualanswer);
+                    $this->assertContainsEquals($returnedfromsave->id, (array)$actualanswer);
+                    $this->assertContainsEquals($ansproperty, array_keys((array)$actualanswer));
                 } else if ($ansproperty !== 'id') {
-                    $this->assertAttributeEquals($ansvalue, $ansproperty, $actualanswer);
+                    $this->assertContainsEquals($ansvalue, (array)$actualanswer);
+                    $this->assertContainsEquals($ansproperty, array_keys((array)$actualanswer));
                 }
             }
         }
@@ -157,7 +161,7 @@ class qtype_ordering_test extends advanced_testcase {
                     6 => new question_possible_response('Position 6', 0.1666667),
             ),
         );
-        $this->assertEquals($expectedresponseclasses, $possibleresponses, '', 0.0000005);
+        $this->assertEqualsWithDelta($expectedresponseclasses, $possibleresponses, 0.0000005, '');
     }
 
     public function test_get_numberingstyle() {


### PR DESCRIPTION
Hi Gordon,
Our CI server pointed out number of PHPUNIT failure such as:
qtype_ordering_question_test::test_get_correct_response
Error: Call to undefined method qtype_ordering_question_test::assertArraySubset()

/var/www/html/20211025_020001_23_tt_overnight_full/question/type/ordering/tests/question_test.php:284
/var/www/html/20211025_020001_23_tt_overnight_full/lib/phpunit/classes/advanced_testcase.php:80

qtype_ordering_question_test::test_classify_response_correct
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     'Modular' => question_classified_response Object (
         'responseclassid' => 1
         'response' => 'Position 1'
-        'fraction' => 0.1666667
+        'fraction' => 0.16666666666666666
     )
     'Object' => question_classified_response Object (
         'responseclassid' => 2
         'response' => 'Position 2'
-        'fraction' => 0.1666667
+        'fraction' => 0.16666666666666666
     )
     'Oriented' => question_classified_response Object (
         'responseclassid' => 3
         'response' => 'Position 3'
-        'fraction' => 0.1666667
+        'fraction' => 0.16666666666666666
     )
     'Dynamic' => question_classified_response Object (
         'responseclassid' => 4
         'response' => 'Position 4'
-        'fraction' => 0.1666667
+        'fraction' => 0.16666666666666666
     )
     'Learning' => question_classified_response Object (
         'responseclassid' => 5
         'response' => 'Position 5'
-        'fraction' => 0.1666667
+        'fraction' => 0.16666666666666666
     )
     'Environment' => question_classified_response Object (
         'responseclassid' => 6
         'response' => 'Position 6'
-        'fraction' => 0.1666667
+        'fraction' => 0.16666666666666666
     )
 )

/var/www/html/20211025_020001_23_tt_overnight_full/question/type/ordering/tests/question_test.php:399
/var/www/html/20211025_020001_23_tt_overnight_full/lib/phpunit/classes/advanced_testcase.php:80

The are 3 more test failures of either the above type.

The reason being, Declaration of qtype_ordering_test::setUp() and tearDown() to be compatible with PHPUnit\Framework\TestCase::setUp(): void  and :: tearDown (): void  and that  assertArraySubset() and assertAttributeEquals() are deprecated and assertEquals() has to be replaced with assertEqualsWithDelta() based on [https://thephp.cc/articles/migrating-to-phpunit-9]. so i came up with this patch.

