### PR TITLE
Ordering: fix stats calculations when items longer than 100 characters

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -376,16 +376,7 @@ class qtype_ordering extends question_type {
             }
 
             $subqid = question_utils::to_plain_text($answer->answer, $answer->answerformat);
-
-            // Make sure $subqid is no more than 100 bytes.
-            $maxbytes = 100;
-            if (strlen($subqid) > $maxbytes) {
-                $subqid = substr($subqid, 0, $maxbytes);
-                if (preg_match('/^(.|\n)*/u', '', $subqid, $match)) {
-                    $subqid = $match[0]; // Incomplete UTF-8 chars will be removed.
-                }
-            }
-
+            $subqid = core_text::substr($subqid, 0, 100); // Ensure not more than 100 chars.
             $responseclasses[$subqid] = $classes;
         }
 

--- a/tests/behat/preview.feature
+++ b/tests/behat/preview.feature
@@ -26,7 +26,7 @@ Feature: Preview an Ordering question
     When I am on the "ordering-001" "core_question > preview" page logged in as teacher1
     And I expand all fieldsets
     And I set the field "How questions behave" to "Immediate feedback"
-    And I press "Start again with these options"
+    And I press "id_saverestart"
     And I drag "Modular" to space "1" in the ordering question
     And I drag "Object" to space "2" in the ordering question
     And I drag "Oriented" to space "3" in the ordering question
@@ -41,7 +41,7 @@ Feature: Preview an Ordering question
     When I am on the "ordering-001" "core_question > preview" page logged in as teacher1
     And I expand all fieldsets
     And I set the field "How questions behave" to "Immediate feedback"
-    And I press "Start again with these options"
+    And I press "id_saverestart"
     And I drag "Modular" to space "1" in the ordering question
     And I drag "Oriented" to space "4" in the ordering question
     And I drag "Dynamic" to space "3" in the ordering question
@@ -61,7 +61,7 @@ Feature: Preview an Ordering question
     And I am on the "Renamed ordering-001" "core_question > preview" page
     And I expand all fieldsets
     And I set the field "How questions behave" to "Immediate feedback"
-    And I press "Start again with these options"
+    And I press "id_saverestart"
     And I drag "Modular" to space "1" in the ordering question
     And I drag "Oriented" to space "4" in the ordering question
     And I drag "Dynamic" to space "3" in the ordering question

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -175,6 +175,15 @@ class questiontype_test extends \advanced_testcase {
         $this->assertEqualsWithDelta($expectedresponseclasses, $possibleresponses, 0.0000005, '');
     }
 
+    public function test_get_possible_responses_very_long() {
+        $questiondata = test_question_maker::get_question_data('ordering');
+        $onehundredchars = str_repeat('1234567890', 9) . '123456789碁';
+        // Set one of the answers to over 100 chars, with a multi-byte UTF-8 character at position 100.
+        $questiondata->options->answers[13]->answer = $onehundredchars . 'and some more';
+        $possibleresponses = $this->qtype->get_possible_responses($questiondata);
+        $this->assertArrayHasKey($onehundredchars, $possibleresponses);
+    }
+
     public function test_get_numberingstyle() {
         $questiondata = test_question_maker::get_question_data('ordering');
         $expected = qtype_ordering_question::NUMBERING_STYLE_DEFAULT;


### PR DESCRIPTION
Hi Gordon. With PHP 8.1, we were getting errors from the Ordering stats calculations, specifically the get_possible_responses.

The error messages we got where:

```
Warning: Undefined variable $match in /var/www/html/moodle/question/type/ordering/questiontype.php on line 384

Deprecated: preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated in /var/www/html/moodle/question/type/ordering/questiontype.php on line 384

Warning: Undefined variable $match in /var/www/html/moodle/question/type/ordering/questiontype.php on line 385

Warning: Trying to access array offset on value of type null in /var/www/html/moodle/question/type/ordering/questiontype.php on line 385
```

The problem is what we were calling preg_match as part of shortening the text of drag items longer than 100 characters, we ahd the arguments in the wrong place. Anyway, once I started looking at it, I reaised that we did not need to code this ourselves. core_text provides a Unicode-safe way to do this, and has for a long time.

I added a unit test to verify what it was doing. Let me know if you have any questions. Thanks.