### PR TITLE
Ordering M4.2: Changes to export_to_xml - remove unused answerfiles

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -806,7 +806,6 @@ class qtype_ordering extends question_type {
         foreach ($question->options->answers as $answer) {
             $output .= '    <answer fraction="'.$answer->fraction.'" '.$format->format($answer->answerformat).">\n";
             $output .= $format->writetext($answer->answer, 3);
-            $output .= $format->write_files($answer->answerfiles);
             if ($feedback = trim($answer->feedback)) { // Usually there is no feedback.
                 $output .= '      <feedback '.$format->format($answer->feedbackformat).">\n";
                 $output .= $format->writetext($answer->feedback, 4);


### PR DESCRIPTION
Hi Gordon,

We recently did upgrade to Moodle 4.2.2 and saw one of the Behat test was failing. 

Dynamic properties creation are now deprecated in M4.2 (https://tracker.moodle.org/browse/MDL-77328), because of which the 'Export a Matching question' Behat test was failing with the error "Undefined property: stdClass::$answerfiles". As we don't set/use answerfiles in ordering question type, I have removed that line from the code in export_to_xml function. Could you please review the changes and suggest if this looks fine?

Scenario: 'Export a Matching question'
Error:
Then following "click here" should download between "1700" and "2350" bytes: Error while downloading data from click here (Behat\Mink\Exception\ExpectationException)

Error: Exception - Warning: Undefined property: stdClass::$answerfiles in [dirroot]\question\type\ordering\questiontype.php on line 809

line 157 of \lib\behat\lib.php: Exception thrown
line 809 of \question\type\ordering\questiontype.php: call to behat_error_handler()
line 888 of \question\format.php: call to qtype_ordering->export_to_xml()
line 1538 of \question\format\xml\format.php: call to qformat_default->try_exporting_using_qtypes()
line 1017 of \question\format.php: call to qformat_xml->writequestion()
line 1819 of \lib\questionlib.php: call to qformat_default->exportprocess()
line 5108 of \lib\filelib.php: call to question_pluginfile()
line 44 of \pluginfile.php: call to file_pluginfile()

Thanks, 
Anupama