### PR TITLE
Save hints as the question author wants them

### DIFF
--- a/tests/behat/add.feature
+++ b/tests/behat/add.feature
@@ -37,3 +37,18 @@ Feature: Test creating an Ordering question
       | hintshownumcorrect[1]              | 1                                |
       | shownumcorrect                     | 1                                |
     Then I should see "Ordering-001"
+
+  Scenario: Ordering questions are created with only the number of hints that are defined
+    Given the following config values are set as admin:
+      | behaviour | interactive | question_preview |
+    When I add a "Ordering" question filling the form with:
+      | Question name                      | Ordering with one hint           |
+      | Question text                      | Put the words in correct order.  |
+      | id_answer_0                        | one                              |
+      | id_answer_1                        | two                              |
+      | id_answer_2                        | three                            |
+      | Hint 1                             | This is the first and only hint. |
+      | hintoptions[0]                     | 1                                |
+    And I should see "Ordering with one hint"
+    When I am on the "Ordering with one hint" "core_question > preview" page
+    Then I should see "Tries remaining: 2"

--- a/tests/behat/backup_and_restore.feature
+++ b/tests/behat/backup_and_restore.feature
@@ -44,7 +44,7 @@ Feature: Test duplicating a quiz containing a Ordering question
       | For any partially correct response | Parts, but only parts, of your response are correct.                          |
       | For any incorrect response         | That is not right at all.                                                     |
       | id_shownumcorrect                  | 1                                                                             |
-      | id_hintshownumcorrect_0            | 1                                                                             |
-      | id_hintoptions_0                   | 1                                                                             |
-      | id_hintshownumcorrect_1            | 1                                                                             |
-      | id_hintoptions_1                   | 1                                                                             |
+      | id_hintshownumcorrect_0            | 0                                                                             |
+      | id_hintoptions_0                   | 0                                                                             |
+      | id_hintshownumcorrect_1            | 0                                                                             |
+      | id_hintoptions_1                   | 0                                                                             |


### PR DESCRIPTION
There was some old code that forced all questions to have at least 2 hints, but we have teachers who want exactly one hint for a question in their exams.

Also, the hint-saving code was duplicating a lot of core code, so I cleaned it up.

I hope this is OK. If you have any questions, please just ask.