### PR TITLE
Fix warnings when using PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.0'
+          - php: '8.2'
             moodle-branch: 'master'
+            database: 'mariadb'
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
             database: 'pgsql'
           - php: '8.1'
             moodle-branch: 'MOODLE_402_STABLE'
             database: 'mariadb'
           - php: '8.0'
             moodle-branch: 'MOODLE_401_STABLE'
-            database: 'mariadb'
+            database: 'pgsql'
           - php: '7.4'
             moodle-branch: 'MOODLE_400_STABLE'
             database: 'mariadb'

--- a/classes/question_hint_ordering.php
+++ b/classes/question_hint_ordering.php
@@ -74,14 +74,4 @@ class question_hint_ordering extends question_hint_with_parts {
         return new question_hint_ordering($row->id, $row->hint, $row->hintformat,
             $row->shownumcorrect, $row->clearwrong, $row->options);
     }
-
-    /**
-     * Adjust this display options according to the hint settings.
-     *
-     * @param question_display_options $options
-     */
-    public function adjust_display_options(question_display_options $options) {
-        parent::adjust_display_options($options);
-        $options->highlightresponse = $this->highlightresponse;
-    }
 }

--- a/question.php
+++ b/question.php
@@ -67,6 +67,24 @@ class qtype_ordering_question extends question_graded_automatically {
     /** @var int Items are graded relative to their position in the correct answer */
     const GRADING_RELATIVE_TO_CORRECT = 7;
 
+    /** @var int {@see LAYOUT_VERTICAL} or {@see LAYOUT_HORIZONTAL}. */
+    public $layouttype;
+
+    /** @var int {@see SELECT_ALL}, {@see SELECT_RANDOM} or {@see SELECT_CONTIGUOUS}. */
+    public $selecttype;
+
+    /** @var int if {@see $selecttype} is not SELECT_ALL, then the number to select. */
+    public $selectcount;
+
+    /** @var int Which grading strategy to use. One of the GRADING_... constants. */
+    public $gradingtype;
+
+    /** @var bool Should details of the grading calculation be shown to students. */
+    public $showgrading;
+
+    /** @var string How to number the items. A key from the array returned by {@see get_numbering_styles()}. */
+    public $numberingstyle;
+
     // Fields from "qtype_ordering_options" table.
     /** @var string */
     public $correctfeedback;

--- a/renderer.php
+++ b/renderer.php
@@ -93,7 +93,12 @@ class qtype_ordering_renderer extends qtype_with_combined_feedback_renderer {
         }
 
         // In the multi-tries, the highlight response base on the hint highlight option.
-        if (isset($options->highlightresponse) && $options->highlightresponse) {
+        $hint = null;
+        if (method_exists($qa->get_behaviour(), 'get_applicable_hint')) {
+            /** @var \qtype_ordering\question_hint_ordering $hint */
+            $hint = $qa->get_behaviour()->get_applicable_hint();
+        }
+        if ($hint && $hint->highlightresponse) {
             $sortablelist .= ' notactive';
         }
 
@@ -152,7 +157,7 @@ class qtype_ordering_renderer extends qtype_with_combined_feedback_renderer {
                         break;
                 }
 
-                if (isset($options->highlightresponse) && $options->highlightresponse) {
+                if ($hint && $hint->highlightresponse) {
                     $score = $this->get_ordering_item_score($question, $position, $answerid);
                     list($score, $maxscore, $fraction, $percent, $class, $img) = $score;
                     $class = trim("$sortableitem $class");

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -48,7 +48,6 @@ class qtype_ordering_test_helper extends question_test_helper {
     public function make_ordering_question_moodle() {
         question_bank::load_question_definition_classes('ordering');
         $q = new qtype_ordering_question();
-        $q->questionid = $q->id;
         test_question_maker::initialise_a_question($q);
         $q->qtype = question_bank::get_qtype('ordering');
         $q->name = 'Moodle';


### PR DESCRIPTION
Hi Gordon, PHP 8.2 does not like it if you try to set an undelcared fieldon a class. You get warnings like:

PHP Deprecated:  Creation of dynamic property qtype_ordering_question::$layouttype is deprecated in C:\Users\tjh238\workspace\ou-moodle2\question\type\questiontypebase.php on line 1015

This is one way it can be fixed. (I also did another commit to update the CI config to test with Moodle 4.3 and PHP 8.2.)